### PR TITLE
fix: cannot find module

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
   "types": "lib/typescript/src/index.d.ts",
-  "react-native": "src/index",
+  "react-native": "lib/commonjs/index",
   "source": "src/index",
   "files": [
     "lib",


### PR DESCRIPTION
Fails importing npm in React Native because it looks for index in src, which is not bundled. 

